### PR TITLE
Refactor manifest file reading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cdegUtilities
 Title: Suite of functions for processing 'omics data
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: 
     c(person("Eilis", "Hannon", , "e.j.hannon@exeter.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-6840-072X")),

--- a/R/readManifest.r
+++ b/R/readManifest.r
@@ -30,15 +30,29 @@ readManifest <- function(manifestFilePath,
       "Does not exist, please check this."
     )
   }
-  manifest <- data.table::fread(
-    manifestFilePath,
-    skip = 7,
-    fill = TRUE,
-    header = TRUE,
-    sep = ",",
-    stringsAsFactors = FALSE,
-    data.table = FALSE
-  )
+  # Some manifest files contain a header, if so we ignore it
+  firstLine <- readLines(file(manifestFilePath, "r"), n = 1)
+  headerPresent <- !grepl("IlmnID", firstLine)
+  if (headerPresent) {
+    manifest <- data.table::fread(
+      manifestFilePath,
+      skip = 7,
+      fill = TRUE,
+      header = TRUE,
+      sep = ",",
+      stringsAsFactors = FALSE,
+      data.table = FALSE
+    )
+  } else {
+    manifest <- data.table::fread(
+      manifestFilePath,
+      fill = TRUE,
+      header = TRUE,
+      sep = ",",
+      stringsAsFactors = FALSE,
+      data.table = FALSE
+    )
+  }
   manifest <- manifest[match(probeMatchingIndex, manifest$IlmnID), ]
   colnames(manifest) <- gsub(
     "Infinium_Design_Type",

--- a/R/readManifest.r
+++ b/R/readManifest.r
@@ -3,8 +3,8 @@
 #' Reads in a manifest file that has a very specific file name depending on
 #' the given array type. Important columns are standardised by name and contents
 #'
-#' @param manifestFilePath This is a string pointing to the manifest file, expected
-#'  to be a csv file.
+#' @param manifestFilePath This is a string pointing to the manifest file,
+#'  expected to be a csv file.
 #' @param probeMatchingIndex This is a vector of probe IDs that are present
 #'  in your dataset. This could be obtained via extracting the rownames of your
 #'  raw beta matrix, or from a gds file that contains probe IDs.
@@ -30,6 +30,7 @@ readManifest <- function(manifestFilePath,
       "Does not exist, please check this."
     )
   }
+
   # Some manifest files contain a header, if so we ignore it
   firstLine <- readLines(file(manifestFilePath, "r"), n = 1)
   headerPresent <- !grepl("IlmnID", firstLine)
@@ -53,11 +54,30 @@ readManifest <- function(manifestFilePath,
       data.table = FALSE
     )
   }
+
+  manifest <- normaliseColumnNames(manifest)
+
   manifest <- manifest[match(probeMatchingIndex, manifest$IlmnID), ]
-  colnames(manifest) <- gsub(
-    "Infinium_Design_Type",
-    "designType",
-    colnames(manifest)
-  )
+  return(manifest)
+}
+
+normaliseColumnNames <- function(manifest) {
+  if (!"IlmnID" %in% colnames(manifest)) {
+    stop("Manifest file has no recognised IlmnID (Illumina ID) column.")
+  }
+  if ("chr" %in% colnames(manifest)) {
+    colnames(manifest) <- gsub(
+      "chr",
+      "CHR",
+      colnames(manifest)
+    )
+  }
+  if ("Infinium_Design_Type" %in% colnames(manifest)) {
+    colnames(manifest) <- gsub(
+      "Infinium_Design_Type",
+      "designType",
+      colnames(manifest)
+    )
+  }
   return(manifest)
 }

--- a/R/readManifest.r
+++ b/R/readManifest.r
@@ -3,118 +3,47 @@
 #' Reads in a manifest file that has a very specific file name depending on
 #' the given array type. Important columns are standardised by name and contents
 #'
-#' @param referenceDirectory This is a string pointing to the directory in
-#'  which the manifest files exist in. It is expected to contain:
-#'  "450K_reference/AllProbeIlluminaAnno.Rdata"
-#'  "EPICArray/EPIC.anno.CRCh38.tsv"
-#'  "EPICArray/EPIC-8v2-0_A1.csv"
+#' @param manifestFilePath This is a string pointing to the manifest file, expected
+#'  to be a csv file.
 #' @param probeMatchingIndex This is a vector of probe IDs that are present
 #'  in your dataset. This could be obtained via extracting the rownames of your
 #'  raw beta matrix, or from a gds file that contains probe IDs.
-#' @param arrayType This is a string with a value from c("450K", "V1", "V2")
 #'
-#' @return A data frame with varying columns. Certain columns are standardised:
-#'  designType - The infinium design type
-#'  CHR - The chromosome number in the form 'chrxyz'
+#' @return A data frame generated from the chosen Illumina manifest file.
+#'  Probes/Rows retained will match the probeMatchingIndex provided.
 #'
 #' @examples manifest <- readManifest(
-#'   "path/to/references",
+#'   "path/to/manifest_file.csv",
 #'   rownames(beta_matrix),
-#'   "V1"
 #' )
 #' manifest <- readManifest(
-#'   "path/to/references",
+#'   "path/to/manifest_file.csv",
 #'   Biobase::fData(gds_file)[["Probe_ID"]],
-#'   "450K"
 #' )
 #' @export
-readManifest <- function(referenceDirectory,
-                         probeMatchingIndex,
-                         arrayType = c("450K", "V1", "V2")) {
-  if (!file.exists(referenceDirectory)) {
+readManifest <- function(manifestFilePath,
+                         probeMatchingIndex) {
+  if (!file.exists(manifestFilePath)) {
     stop(
-      "Reference directory: ",
-      referenceDirectory,
+      "Manifest file: ",
+      manifestFilePath,
       "Does not exist, please check this."
     )
   }
-  arrayType <- match.arg(arrayType)
-  if (arrayType == "450K") {
-    hm450Kmanifest <- file.path(
-      referenceDirectory,
-      "450K_reference",
-      "AllProbeIlluminaAnno.Rdata"
-    )
-    if (!file.exists(hm450Kmanifest)) {
-      stop(
-        "Manifest: ",
-        hm450Kmanifest,
-        "Does not exist, please check this."
-      )
-    }
-    # Loads probeAnnot (needs generalising in the future)
-    load(hm450Kmanifest)
-    manifest <- probeAnnot[match(probeMatchingIndex, probeAnnot$TargetID), ]
-    colnames(manifest) <- gsub(
-      "INFINIUM_DESIGN_TYPE",
-      "designType",
-      colnames(manifest)
-    )
-    manifest[["CHR"]] <- paste0("chr", manifest[["CHR"]])
-  }
-
-  if (arrayType == "V1") {
-    epicV1Manifest <- file.path(
-      referenceDirectory,
-      "EPICArray",
-      "EPIC.anno.GRCh38.tsv"
-    )
-    if (!file.exists(epicV1Manifest)) {
-      stop(
-        "Manifest: ",
-        epicV1Manifest,
-        "Does not exist, please check this."
-      )
-    }
-    manifest <- data.table::fread(
-      epicV1Manifest,
-      fill = TRUE,
-      header = TRUE,
-      sep = "\t",
-      stringsAsFactors = FALSE,
-      data.table = FALSE
-    )
-    manifest <- manifest[match(probeMatchingIndex, manifest$probeID), ]
-  }
-
-  if (arrayType == "V2") {
-    epicV2Manifest <- file.path(
-      referenceDirectory,
-      "EPICArray",
-      "EPIC-8v2-0_A1.csv"
-    )
-    if (!file.exists(epicV2Manifest)) {
-      stop(
-        "Manifest: ",
-        epicV2Manifest,
-        "Does not exist, please check this."
-      )
-    }
-    manifest <- data.table::fread(
-      epicV2Manifest,
-      skip = 7,
-      fill = TRUE,
-      header = TRUE,
-      sep = ",",
-      stringsAsFactors = FALSE,
-      data.table = FALSE
-    )
-    manifest <- manifest[match(probeMatchingIndex, manifest$IlmnID), ]
-    colnames(manifest) <- gsub(
-      "Infinium_Design_Type",
-      "designType",
-      colnames(manifest)
-    )
-  }
+  manifest <- data.table::fread(
+    manifestFilePath,
+    skip = 7,
+    fill = TRUE,
+    header = TRUE,
+    sep = ",",
+    stringsAsFactors = FALSE,
+    data.table = FALSE
+  )
+  manifest <- manifest[match(probeMatchingIndex, manifest$IlmnID), ]
+  colnames(manifest) <- gsub(
+    "Infinium_Design_Type",
+    "designType",
+    colnames(manifest)
+  )
   return(manifest)
 }

--- a/R/readManifest.r
+++ b/R/readManifest.r
@@ -56,6 +56,7 @@ readManifest <- function(manifestFilePath,
   }
 
   manifest <- normaliseColumnNames(manifest)
+  checkRequiredColumns(manifest)
 
   manifest <- manifest[match(probeMatchingIndex, manifest$IlmnID), ]
   return(manifest)
@@ -76,6 +77,10 @@ normaliseColumnNames <- function(manifest) {
       colnames(manifest)
     )
   }
+  return(manifest)
+}
+
+checkRequiredColumns <- function(manifest) {
   if (!"IlmnID" %in% colnames(manifest)) {
     stop("Manifest file has no recognised IlmnID (Illumina ID) column.")
   }
@@ -85,5 +90,4 @@ normaliseColumnNames <- function(manifest) {
   if (!"designType" %in% colnames(manifest)) {
     stop("Manifest file has no recognised design type column.")
   }
-  return(manifest)
 }

--- a/R/readManifest.r
+++ b/R/readManifest.r
@@ -62,9 +62,6 @@ readManifest <- function(manifestFilePath,
 }
 
 normaliseColumnNames <- function(manifest) {
-  if (!"IlmnID" %in% colnames(manifest)) {
-    stop("Manifest file has no recognised IlmnID (Illumina ID) column.")
-  }
   if ("chr" %in% colnames(manifest)) {
     colnames(manifest) <- gsub(
       "chr",
@@ -78,6 +75,15 @@ normaliseColumnNames <- function(manifest) {
       "designType",
       colnames(manifest)
     )
+  }
+  if (!"IlmnID" %in% colnames(manifest)) {
+    stop("Manifest file has no recognised IlmnID (Illumina ID) column.")
+  }
+  if (!"CHR" %in% colnames(manifest)) {
+    stop("Manifest file has no recognised chromosome column.")
+  }
+  if (!"designType" %in% colnames(manifest)) {
+    stop("Manifest file has no recognised design type column.")
   }
   return(manifest)
 }


### PR DESCRIPTION
The `readManifest` function will now accept a path instead of requiring hard coded paths. The error checking associated is better now and it only accepts csv files (previously it was extracting data from an `.rdat` file, which was due to legacy code).